### PR TITLE
Fix Internet Explorer 11 bug

### DIFF
--- a/kube/src/js/dom/Dom.js
+++ b/kube/src/js/dom/Dom.js
@@ -343,7 +343,7 @@ Dom.prototype = {
 
             for (var key in attrs)
             {
-                if (reDataAttr.test(attrs[key].nodeName))
+                if (attrs[key] && reDataAttr.test(attrs[key].nodeName))
                 {
                     var dataName = attrs[key].nodeName.match(reDataAttr)[1];
                     var val = attrs[key].value;


### PR DESCRIPTION
IE 11 throws an error when accessing nodeName on an undefined object. This fix allows Kube's JavaScript to work on IE 11.