### PR TITLE
Add support for fractional step in number inputs

### DIFF
--- a/kube/src/js/addons/number/number.js
+++ b/kube/src/js/addons/number/number.js
@@ -37,7 +37,13 @@
     	{
             var step = this.$input.attr('step');
             this.step = (step) ? parseFloat(step) : 1;
-    	},
+
+            for (var limit = 1, precision = 1; precision < 5; limit /= 10, precision++) {
+                if (this.step < limit) {
+                    this.fixedPrecision = precision
+                }
+            }
+        },
     	_buildMin: function()
     	{
             var min = this.$input.attr('min');
@@ -70,7 +76,7 @@
             var oldValue = this._getValue();
             var newVal = (this.max !== false && oldValue >= this.max) ? oldValue : oldValue + this.step;
 
-            this.$input.val(newVal);
+            this.$input.val(newVal.toFixed(this.fixedPrecision));
         },
         _decrease: function(e)
         {
@@ -83,7 +89,7 @@
             var oldValue = this._getValue();
             var newVal = (this.min !== false && oldValue <= this.min) ? oldValue : oldValue - this.step;
 
-            this.$input.val(newVal);
+            this.$input.val(newVal.toFixed(this.fixedPrecision));
     	}
     });
 })(Kube);


### PR DESCRIPTION
Without this fix input value incremented by plus/minus buttons accumulates rounding errors. For instance value will be 5.284999999999998 instead of 5.285. This rounding error triggers browser errors.

Mozilla Firefox displays "Please select a valid value. The two nearest valid values are 5.28 and 5.285." message. This makes no sense to end user, who sees 5.285 (rounded 5.284999999999998) and can;t understand why browser does not like "5.285" and suggests "5.285" instead.

Microsoft Edge displays "You must enter a valid value" and non-rounded value.

Google Chrome displays no error message, displays and submits non-rounded value which is still confused.