### PR TITLE
Alignment cannot be overridden.

### DIFF
--- a/kube/src/sass/addons/number.scss
+++ b/kube/src/sass/addons/number.scss
@@ -16,7 +16,6 @@
     & input[type=number] {
         -moz-appearance: textfield;
         width: auto;
-        text-align: center;
     }
 
     & input {


### PR DESCRIPTION
Right alignment is not as useful for numbers as right alignment. Anyway text-align specified in "input[type=number]" cannot be overridden by "is-text-right" class. So it looks more logical to me to not specify text alignment at all.