### PR TITLE
Close datepicker on Tab as well as escape

### DIFF
--- a/kube/src/js/addons/datepicker/datepicker.js
+++ b/kube/src/js/addons/datepicker/datepicker.js
@@ -332,7 +332,7 @@
         // EVENTS
         _handleKeyboard: function(e)
     	{
-    		if (e.which === 27) this._close();
+    		if (e.key === "Escape" || e.key == "Tab") this._close();
     	},
     	_enableEvents: function()
     	{


### PR DESCRIPTION
Currently, if a user selects a datepicker element, and then moves to the next element using Tab, the datepicker remains open. This commit closes the datepicker on Tab as well as Enter.