### PR TITLE
Use selected element's text rather than HTML in Autocomplete

### DIFF
--- a/kube/src/js/addons/autocomplete/autocomplete.js
+++ b/kube/src/js/addons/autocomplete/autocomplete.js
@@ -210,7 +210,7 @@
     		}
 
     		var id = $active.attr('rel');
-            var value = $active.html();
+                var value = $active.text();
 
             if (this.$target.length !== 0)
             {


### PR DESCRIPTION
Use the selected element's text, rather than HTML, when setting the
value of the autocomplete element to convert escaped characters, such
as &amp, back to their original values. This allows values such as
"foo <br> bar" to be included in a list of autocomplete options.

Before this commit:
Type "foo & bar" in autocomplete element
Select "foo & bar" from list of suggested options
Autocomplete element's value set to "foo &amp bar"

After this commit:
Type "foo & bar" in autocomplete element
Select "foo & bar" from list of suggested options
Autocomplete element's value set to "foo & bar"